### PR TITLE
Use full variable syntax

### DIFF
--- a/tasks/application.yml
+++ b/tasks/application.yml
@@ -101,7 +101,7 @@
     ensure: "{{ item.ensure|default('present') }}"
     attribute: "{{ item.attribute|default(omit) }}"
     value: "{{ item.value|default(omit) }}"
-  with_items: atlassian_confluence_server_xml
+  with_items: "{{ atlassian_confluence_server_xml }}"
   tags:
     - atlassian-confluence
 

--- a/tasks/crowdsso.yml
+++ b/tasks/crowdsso.yml
@@ -30,7 +30,7 @@
     regexp: "^\\s*{{ item.name }}\\s+"
     line: "{{ item.name }}\t\t{{ item.value }}"
     insertafter: EOF
-  with_items: atlassian_confluence_crowd_properties|default([])
+  with_items: "{{ atlassian_confluence_crowd_properties|default([]) }}"
   tags:
     - atlassian-confluence
 
@@ -51,7 +51,7 @@
     attribute: "{{ item.attribute|default(omit) }}"
     ensure: "{{ item.ensure|default('present') }}"
     value: "{{ item.value|default(omit) }}"
-  with_items: atlassian_confluence_seraph_config
+  with_items: "{{ atlassian_confluence_seraph_config }}"
   tags:
     - atlassian-confluence
 


### PR DESCRIPTION
Bare syntax was deprecated already, and as of 2.2.0.0 calling vars like that won't work any more.
Instead, you'll get fatal errors such as:
`FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'unicode object' has no attribute 'xpath'`